### PR TITLE
Results screen layout and improved sharing

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -3,5 +3,15 @@
     <option name="myName" value="Project Default" />
     <inspection_tool class="CheckEmptyScriptTag" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ExceptionCaughtLocallyJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="style:display" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
   </profile>
 </component>

--- a/src/components/LastGameDetail.svelte
+++ b/src/components/LastGameDetail.svelte
@@ -182,7 +182,7 @@
 						on:click={toggleOption.click}
 						hideLabel
 						label={$t(toggleOption.label)}
-						style="transform: scale(1.6); touch-action: manipulation;"
+						style="transform: scale(1.6); touch-action: manipulation; flex-basis: 2.5rem;"
 						toggledColor="var(--accent-color)"
 						untoggledColor="#695d6e"
 					>

--- a/src/components/LastGameDetail.svelte
+++ b/src/components/LastGameDetail.svelte
@@ -1,9 +1,119 @@
 <script lang="ts">
+	import { beforeUpdate, onMount } from 'svelte'
 	import { t } from '$lib/translations'
 	import Time from '$com/Time.svelte'
 	import type { GameDetail } from '$lib/stats'
+	import type { Writable } from 'svelte/store'
+	import { get } from 'svelte/store'
+	import Toggle from 'svelte-toggle'
+	import * as store from '$src/store'
+	import {
+		copyImage,
+		copyText,
+		drawResults,
+		getEmojiGrid,
+		getShareTitle,
+		shareImage,
+	} from '$lib/share'
+	import { trackEvent } from '$lib/plausible'
+	import { toast } from '@zerodevx/svelte-toast'
 
 	export let lastGameDetail: GameDetail | null
+
+	type SpanContainer = { span?: HTMLSpanElement }
+	const totalTimeElement: SpanContainer = { span: undefined }
+	const guessTimeElements: SpanContainer[] = []
+
+	let canvas: HTMLCanvasElement
+	let shareTitleText: string
+	let shareMenu: boolean
+	let imageShared: boolean
+
+	const toastOptions = { theme: { '--toastBackground': 'var(--cta-color)' } }
+	const successToast = (message: string) => toast.push(message, toastOptions)
+	const errorToast = () => toast.push(get(t)('main.messages.could_not_do'), toastOptions)
+
+	function shareText() {
+		shareMenu = false
+		trackEvent('resultShare')
+		const emojiGridParams: Parameters<typeof getEmojiGrid>[0] = {
+			guesses: get(store.guesses),
+			answer: get(store.answer),
+		}
+		let totalTime = ''
+		if (get(store.shareTimes)) {
+			totalTime = `\n${get(t)('main.summary.total_time')}: ${totalTimeElement.span!.innerText}`
+			emojiGridParams.guessTimes = guessTimeElements.map((e) => e.span!.innerText)
+		}
+		let url = ''
+		if (get(store.shareURL)) {
+			url = '\nhttps://wordlepeaks.com'
+			if (lastGameDetail!.hash) url += `/#${lastGameDetail!.hash}`
+		}
+		copyText(shareTitleText + '\n\n' + getEmojiGrid(emojiGridParams) + totalTime + url).then(
+			() => successToast(get(t)('main.messages.score_copied')),
+			() => errorToast()
+		)
+	}
+
+	async function onShareImage() {
+		shareMenu = false
+		imageShared = true
+		trackEvent('resultShare')
+		await shareImage(
+			canvas,
+			lastGameDetail!.mode === 'random'
+				? { hash: lastGameDetail!.hash }
+				: { day: lastGameDetail!.dayNumber }
+		)
+	}
+
+	function onCopyImage() {
+		try {
+			copyImage(canvas)
+			successToast(get(t)('main.messages.image_copied'))
+		} catch (e) {
+			errorToast()
+		}
+	}
+
+	const toggle = (prop: Writable<boolean>) => () => prop.set(!get(prop))
+
+	const toggleOptions = [
+		{
+			bind: store.shareURL,
+			label: 'main.options.include_link',
+			click: toggle(store.shareURL),
+		},
+		{
+			bind: store.shareTimes,
+			label: 'main.options.include_times',
+			click: toggle(store.shareTimes),
+		},
+	]
+
+	beforeUpdate(() => {
+		if (guessTimeElements.length > 0) return
+		lastGameDetail!.guesses.forEach(() => {
+			guessTimeElements.push({ span: undefined })
+		})
+	})
+
+	onMount(() => {
+		shareTitleText = getShareTitle({
+			gameWon: get(store.gameWon),
+			guesses: get(store.guesses),
+			gameMode: lastGameDetail!.mode,
+			hardMode: get(store.lastPlayedWasHard),
+			day: lastGameDetail!.dayNumber,
+		})
+		drawResults(canvas, {
+			highContrast: get(store.highContrast),
+			boardContent: get(store.boardContent),
+			guesses: get(store.guesses),
+			caption: shareTitleText,
+		})
+	})
 </script>
 
 <section>
@@ -28,7 +138,10 @@
 		</div>
 		<div class="info-item">
 			<strong>
-				<Time ms={lastGameDetail.guessTimes.at(-1) - lastGameDetail.guessTimes[0]} />
+				<Time
+					bindContainer={totalTimeElement}
+					ms={lastGameDetail.guessTimes.at(-1) - lastGameDetail.guessTimes[0]}
+				/>
 			</strong>
 			{$t('main.summary.total_time')}
 		</div>
@@ -48,10 +161,44 @@
 					{/each}
 				</div>
 				<div class="time-value">
-					<Time ms={lastGameDetail.guessTimes[g + 1] - lastGameDetail.guessTimes[g]} />
+					<Time
+						bindContainer={guessTimeElements[g]}
+						ms={lastGameDetail.guessTimes[g + 1] - lastGameDetail.guessTimes[g]}
+					/>
 				</div>
 			</div>
 		{/each}
+	</div>
+	<div class="share">
+		{#if shareMenu}
+			<div class="share-buttons">
+				<button on:click={shareText} class="share-button">{$t('main.results.text')}</button>
+				<button on:click={onShareImage} class="share-button">{$t('main.results.image')}</button>
+			</div>
+			<div class="share-options">
+				{#each toggleOptions as toggleOption}
+					<Toggle
+						toggled={get(toggleOption.bind)}
+						on:click={toggleOption.click}
+						hideLabel
+						label={$t(toggleOption.label)}
+						style="transform: scale(1.6); touch-action: manipulation;"
+						toggledColor="var(--accent-color)"
+						untoggledColor="#695d6e"
+					>
+						<div class="label">{$t(toggleOption.label)}</div>
+					</Toggle>
+				{/each}
+			</div>
+		{:else}
+			<button on:click={() => (shareMenu = true)} class="share-button"
+				>{$t('main.results.share')}</button
+			>
+		{/if}
+	</div>
+	<div class="image-share" style:display={imageShared ? 'flex' : 'none'}>
+		<canvas bind:this={canvas} width="504" height="0" style={'width:252px'} />
+		<button on:click={onCopyImage} class="share-button">{$t('main.results.copy_image')}</button>
 	</div>
 </section>
 
@@ -135,6 +282,89 @@
 		display: flex;
 		justify-content: flex-end;
 		align-items: center;
+	}
+
+	.share {
+		margin-top: 1.4rem;
+		width: 100%;
+		padding: 0 7%;
+		box-sizing: border-box;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.share > button {
+		font-size: 1.5em;
+		height: 4rem;
+		min-width: 15rem;
+	}
+
+	.share-buttons {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		flex-grow: 1;
+	}
+
+	.share-buttons button {
+		margin: 0.3rem 0;
+		padding: 0 1rem;
+		min-width: 100%;
+	}
+
+	.share-options {
+		max-width: 220px;
+		margin: 0 1rem;
+		flex-grow: 2;
+	}
+
+	.label {
+		order: -1;
+		flex-grow: 1.5;
+		font-size: 1.2em;
+		margin: 0.5rem 0;
+		padding: 0.4rem 0.8rem 0.4rem 0;
+	}
+
+	button {
+		border-radius: 4px;
+		border: 0;
+		padding: 0;
+		height: 3rem;
+		font-size: 1.2em;
+		font-weight: 700;
+		min-width: 10rem;
+	}
+
+	button:focus {
+		outline: 1px solid #fff;
+		outline-offset: 2px;
+	}
+
+	button.share-button {
+		background: var(--cta-color);
+	}
+
+	button.share-button:hover {
+		background: #3388de;
+	}
+
+	.image-share {
+		margin-top: 1rem;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		gap: 0.8rem;
+	}
+
+	.image-share canvas {
+		padding: 4px;
+		border: 1px solid var(--primary-color);
+		box-shadow: 0 0 8px var(--primary-color);
+		/*transform: scale(0.5);*/
 	}
 
 	@media (max-width: 360px) {

--- a/src/components/LastGameDetail.svelte
+++ b/src/components/LastGameDetail.svelte
@@ -200,7 +200,7 @@
 		{/if}
 	</div>
 	<div class="image-share" style:display={imageShared ? 'flex' : 'none'}>
-		<canvas bind:this={canvas} height="0" style={'width:252px'} />
+		<canvas bind:this={canvas} />
 		<button on:click={onCopyImage}>{$t('main.results.copy_image')}</button>
 	</div>
 </section>

--- a/src/components/LastGameDetail.svelte
+++ b/src/components/LastGameDetail.svelte
@@ -66,6 +66,7 @@
 			guesses: get(store.guesses),
 			caption: shareTitleText,
 			guessTimes: get(store.shareTimes) ? getGuessTimes() : undefined,
+			totalTime: get(store.shareTimes) ? totalTimeElement.span!.innerText : undefined,
 			showURL: get(store.shareURL),
 			hash: lastGameDetail!.hash || undefined,
 		})
@@ -199,7 +200,7 @@
 			<button on:click={() => (shareMenu = true)}>{$t('main.results.share')}</button>
 		{/if}
 	</div>
-	<div class="image-share" style:display={imageShared ? 'flex' : 'none'}>
+	<div class="image-share" style:display={imageShared && !shareMenu ? 'flex' : 'none'}>
 		<canvas bind:this={canvas} />
 		<button on:click={onCopyImage}>{$t('main.results.copy_image')}</button>
 	</div>

--- a/src/components/LastGameDetail.svelte
+++ b/src/components/LastGameDetail.svelte
@@ -66,6 +66,7 @@
 				? { hash: lastGameDetail!.hash }
 				: { day: lastGameDetail!.dayNumber }
 		)
+		canvas.scrollIntoView({ block: 'center' })
 	}
 
 	function onCopyImage() {
@@ -172,8 +173,8 @@
 	<div class="share">
 		{#if shareMenu}
 			<div class="share-buttons">
-				<button on:click={shareText} class="share-button">{$t('main.results.text')}</button>
-				<button on:click={onShareImage} class="share-button">{$t('main.results.image')}</button>
+				<button on:click={shareText}>{$t('main.results.text')}</button>
+				<button on:click={onShareImage}>{$t('main.results.image')}</button>
 			</div>
 			<div class="share-options">
 				{#each toggleOptions as toggleOption}
@@ -191,14 +192,12 @@
 				{/each}
 			</div>
 		{:else}
-			<button on:click={() => (shareMenu = true)} class="share-button"
-				>{$t('main.results.share')}</button
-			>
+			<button on:click={() => (shareMenu = true)}>{$t('main.results.share')}</button>
 		{/if}
 	</div>
 	<div class="image-share" style:display={imageShared ? 'flex' : 'none'}>
 		<canvas bind:this={canvas} width="504" height="0" style={'width:252px'} />
-		<button on:click={onCopyImage} class="share-button">{$t('main.results.copy_image')}</button>
+		<button on:click={onCopyImage}>{$t('main.results.copy_image')}</button>
 	</div>
 </section>
 
@@ -207,7 +206,7 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		padding: 2em 0;
+		padding: 2rem 0.5rem;
 	}
 
 	.info {
@@ -295,6 +294,26 @@
 		justify-content: center;
 	}
 
+	button {
+		border-radius: 4px;
+		border: 0;
+		padding: 0 1rem;
+		height: 3rem;
+		font-size: 1.2em;
+		font-weight: 700;
+		min-width: 10rem;
+		background: var(--cta-color);
+	}
+
+	button:hover {
+		background: #3388de;
+	}
+
+	button:focus {
+		outline: 1px solid #fff;
+		outline-offset: 2px;
+	}
+
 	.share > button {
 		font-size: 1.5em;
 		height: 4rem;
@@ -310,7 +329,6 @@
 
 	.share-buttons button {
 		margin: 0.3rem 0;
-		padding: 0 1rem;
 		min-width: 100%;
 	}
 
@@ -326,29 +344,6 @@
 		font-size: 1.2em;
 		margin: 0.5rem 0;
 		padding: 0.4rem 0.8rem 0.4rem 0;
-	}
-
-	button {
-		border-radius: 4px;
-		border: 0;
-		padding: 0;
-		height: 3rem;
-		font-size: 1.2em;
-		font-weight: 700;
-		min-width: 10rem;
-	}
-
-	button:focus {
-		outline: 1px solid #fff;
-		outline-offset: 2px;
-	}
-
-	button.share-button {
-		background: var(--cta-color);
-	}
-
-	button.share-button:hover {
-		background: #3388de;
 	}
 
 	.image-share {

--- a/src/components/LastGameDetail.svelte
+++ b/src/components/LastGameDetail.svelte
@@ -23,6 +23,7 @@
 	type SpanContainer = { span?: HTMLSpanElement }
 	const totalTimeElement: SpanContainer = { span: undefined }
 	const guessTimeElements: SpanContainer[] = []
+	const getGuessTimes = () => guessTimeElements.map((e) => e.span!.innerText)
 
 	let canvas: HTMLCanvasElement
 	let shareTitleText: string
@@ -42,8 +43,8 @@
 		}
 		let totalTime = ''
 		if (get(store.shareTimes)) {
-			totalTime = `\n${get(t)('main.summary.total_time')}: ${totalTimeElement.span!.innerText}`
-			emojiGridParams.guessTimes = guessTimeElements.map((e) => e.span!.innerText)
+			totalTime = `\n  ${get(t)('main.summary.total_time')}: ${totalTimeElement.span!.innerText}`
+			emojiGridParams.guessTimes = getGuessTimes()
 		}
 		let url = ''
 		if (get(store.shareURL)) {
@@ -59,6 +60,15 @@
 	async function onShareImage() {
 		shareMenu = false
 		imageShared = true
+		drawResults(canvas, {
+			highContrast: get(store.highContrast),
+			boardContent: get(store.boardContent),
+			guesses: get(store.guesses),
+			caption: shareTitleText,
+			guessTimes: get(store.shareTimes) ? getGuessTimes() : undefined,
+			showURL: get(store.shareURL),
+			hash: lastGameDetail!.hash || undefined,
+		})
 		trackEvent('resultShare')
 		await shareImage(
 			canvas,
@@ -107,12 +117,6 @@
 			gameMode: lastGameDetail!.mode,
 			hardMode: get(store.lastPlayedWasHard),
 			day: lastGameDetail!.dayNumber,
-		})
-		drawResults(canvas, {
-			highContrast: get(store.highContrast),
-			boardContent: get(store.boardContent),
-			guesses: get(store.guesses),
-			caption: shareTitleText,
 		})
 	})
 </script>
@@ -196,7 +200,7 @@
 		{/if}
 	</div>
 	<div class="image-share" style:display={imageShared ? 'flex' : 'none'}>
-		<canvas bind:this={canvas} width="504" height="0" style={'width:252px'} />
+		<canvas bind:this={canvas} height="0" style={'width:252px'} />
 		<button on:click={onCopyImage}>{$t('main.results.copy_image')}</button>
 	</div>
 </section>

--- a/src/components/Options.svelte
+++ b/src/components/Options.svelte
@@ -97,7 +97,7 @@
 				on:click={toggleOption.click}
 				hideLabel
 				label={$t(toggleOption.label)}
-				style="transform: scale(1.6); touch-action: manipulation;"
+				style="transform: scale(1.6); touch-action: manipulation; flex-basis: 2.5rem;"
 				toggledColor="var(--accent-color)"
 				untoggledColor="#695d6e"><div class="label">{$t(toggleOption.label)}</div></Toggle
 			>

--- a/src/components/Options.svelte
+++ b/src/components/Options.svelte
@@ -32,9 +32,7 @@
 		}
 	}
 
-	const toggle = (prop: Writable<boolean>) => () => {
-		prop.set(!get(prop))
-	}
+	const toggle = (prop: Writable<boolean>) => () => prop.set(!get(prop))
 
 	const toggleOptions = [
 		{ bind: hardModeToggle, label: 'main.options.hard_mode', click: toggleHardMode },
@@ -49,11 +47,6 @@
 			bind: store.dyslexicFont,
 			label: 'main.options.use_dyslexic_font',
 			click: toggle(store.dyslexicFont),
-		},
-		{
-			bind: store.shareURL,
-			label: 'main.options.include_link',
-			click: toggle(store.shareURL),
 		},
 	]
 

--- a/src/components/Results.svelte
+++ b/src/components/Results.svelte
@@ -20,7 +20,6 @@
 	let lastGameDetail: GameDetail | null
 	export let playDaily: () => {}
 	export let playRandom: () => {}
-	export let hash: string
 
 	const _guessesDaily = get(store.guessesDaily)
 	const _lastPlayedDaily = get(store.lastPlayedDaily)
@@ -73,9 +72,9 @@
 		</div>
 		<div class="column">
 			{#if lastGameMode === 'random' || nextWordReady || !dailyFinished}
-				<button on:click={playDaily} class="play-button">{$t('main.results.play_daily')}</button>
+				<button on:click={playDaily}>{$t('main.results.play_daily')}</button>
 			{/if}
-			<button on:click={playRandom} class="play-button">{$t('main.results.play_random')}</button>
+			<button on:click={playRandom}>{$t('main.results.play_random')}</button>
 		</div>
 	</div>
 </Screen>
@@ -119,24 +118,16 @@
 		font-size: 1.2em;
 		font-weight: 700;
 		min-width: 10rem;
+		background: #04883b;
+	}
+
+	button:hover {
+		background: var(--correct-color);
 	}
 
 	button:focus {
 		outline: 1px solid #fff;
 		outline-offset: 2px;
-	}
-
-	button.play-button {
-		background: #04883b;
-	}
-
-	button.play-button:hover {
-		background: var(--correct-color);
-	}
-
-	.share-buttons button {
-		min-width: 3rem;
-		width: 50%;
 	}
 
 	.daily-text {

--- a/src/components/Screen.svelte
+++ b/src/components/Screen.svelte
@@ -63,6 +63,7 @@
 	.column {
 		max-width: 520px;
 		width: 100%;
+		margin-top: 60px;
 		display: flex;
 		align-items: flex-start;
 		justify-content: center;
@@ -76,8 +77,10 @@
 		min-height: 60px;
 		background-color: var(--tertiary-color);
 		display: flex;
+		position: fixed;
 		align-items: center;
 		justify-content: center;
+		z-index: 999999;
 	}
 
 	svg {

--- a/src/components/Stats.svelte
+++ b/src/components/Stats.svelte
@@ -50,7 +50,7 @@
 		display: flex;
 		justify-content: center;
 		flex-wrap: wrap;
-		padding: 2em 0;
+		padding: 2rem 0.5rem;
 	}
 
 	.stats-item {

--- a/src/components/Time.svelte
+++ b/src/components/Time.svelte
@@ -24,8 +24,6 @@
 	$: hours = Math.floor(msLeft / HOUR)
 	$: showHours = hours > 0 || alwaysShowHours
 
-	// afterUpdate(() => console.log(span && span.innerText, countdown, ms))
-
 	onDestroy(() => {
 		clearInterval(interval)
 	})

--- a/src/components/Time.svelte
+++ b/src/components/Time.svelte
@@ -4,6 +4,7 @@
 	export let ms: number | false = false
 	export let countdown: number | false = false
 	export let alwaysShowHours: boolean = false
+	export let bindContainer: { span: HTMLSpanElement | undefined } = { span: undefined }
 
 	const padZero = (value: number) => value.toString().padStart(2, '0')
 	const MINUTE = 60 * 1000
@@ -12,7 +13,7 @@
 	let msLeft = countdown ? countdown - new Date() : ms
 
 	let interval
-	if (countdown) {
+	if (countdown && msLeft > 0) {
 		interval = setInterval(() => {
 			msLeft = countdown - new Date()
 		}, 1000)
@@ -23,6 +24,8 @@
 	$: hours = Math.floor(msLeft / HOUR)
 	$: showHours = hours > 0 || alwaysShowHours
 
+	// afterUpdate(() => console.log(span && span.innerText, countdown, ms))
+
 	onDestroy(() => {
 		clearInterval(interval)
 	})
@@ -30,7 +33,7 @@
 
 {#if !countdown || msLeft > 0}
 	<slot name="title" />
-	<span class={$$props.class}>
+	<span bind:this={bindContainer.span} class={$$props.class}>
 		<span class:fade={hours === 0}>{showHours ? hours : ''}</span><span
 			class:fade={minutes === 0 && hours === 0}>{showHours ? ':' + padZero(minutes) : minutes}</span
 		>:{padZero(seconds)}

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -70,25 +70,42 @@ const aprilFoolsDown = [
 	'🔻',
 ]
 const aprilFoolsCorrect = ['🟩', '🐸', '🍀', '🔋', '📗', '💹', '✅', '✳️', '❇️', '🟢']
-export function getEmojiGrid(guesses: string[], answer: string): string {
+export function getEmojiGrid({
+	guesses,
+	answer,
+	guessTimes,
+}: {
+	guesses: string[]
+	answer: string
+	guessTimes?: string[]
+}): string {
 	const today = new Date()
 	const aprilFools = today.getMonth() === 3 && today.getDate() === 1 // April 1st
+	let timeStringPad: number
+	if (guessTimes) {
+		guessTimes[2] = '12:30'
+		timeStringPad = guessTimes.reduce((prev, curr) =>
+			prev === null || prev.length < curr.length ? curr : prev
+		).length
+		console.log(timeStringPad)
+	}
 	return (
 		'  ' +
 		guesses
-			.map((word) =>
-				[...word]
-					.map((letter, l) => {
-						if (letter === answer[l]) return aprilFools ? pickRandom(aprilFoolsCorrect) : '🟩'
-						return letter > answer[l]
-							? aprilFools
-								? pickRandom(aprilFoolsDown)
-								: '🔽'
-							: aprilFools
-							? pickRandom(aprilFoolsUp)
-							: '🔼'
-					})
-					.join('')
+			.map(
+				(word, w) =>
+					[...word]
+						.map((letter, l) => {
+							if (letter === answer[l]) return aprilFools ? pickRandom(aprilFoolsCorrect) : '🟩'
+							return letter > answer[l]
+								? aprilFools
+									? pickRandom(aprilFoolsDown)
+									: '🔽'
+								: aprilFools
+								? pickRandom(aprilFoolsUp)
+								: '🔼'
+						})
+						.join('') + (guessTimes ? ' ' + guessTimes[w].padStart(timeStringPad) : '')
 			)
 			.join('\n  ')
 	)

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -145,6 +145,7 @@ export function drawResults(
 		guesses,
 		caption,
 		guessTimes,
+		totalTime,
 		showURL,
 		hash,
 	}: {
@@ -153,6 +154,7 @@ export function drawResults(
 		guesses: string[]
 		caption: string
 		guessTimes?: string[]
+		totalTime?: string
 		showURL: boolean
 		hash?: string
 	}
@@ -209,16 +211,18 @@ export function drawResults(
 			ctx.fillText(guessTimes[r], canvas.width - 6, r * 100 + 55)
 		}
 	})
-	ctx.fillStyle = '#cccccc'
-	ctx.font = '40px Arial'
-	ctx.textAlign = 'center'
 	ctx.textBaseline = 'alphabetic'
-	ctx.fillText(caption, canvas.width / 2, guesses.length * 100 + 44)
+	ctx.fillStyle = '#cccccc'
+	if (totalTime) ctx.fillText(totalTime, canvas.width - 6, guesses.length * 100 + 44)
+	ctx.font = '40px Arial'
+	ctx.textAlign = totalTime ? 'left' : 'center'
+	ctx.fillText(caption, totalTime ? 8 : canvas.width / 2, guesses.length * 100 + 44)
 	if (showURL) {
+		ctx.font = '40px Arial'
 		let url = 'wordlepeaks.com'
 		if (hash) url += '/#' + hash
 		ctx.fillStyle = '#a7a1a9'
-		ctx.fillText(url, canvas.width / 2, guesses.length * 100 + 92)
+		ctx.fillText(url, totalTime ? 8 : canvas.width / 2, guesses.length * 100 + 92)
 	}
 }
 

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -82,13 +82,7 @@ export function getEmojiGrid({
 	const today = new Date()
 	const aprilFools = today.getMonth() === 3 && today.getDate() === 1 // April 1st
 	let timeStringPad: number
-	if (guessTimes) {
-		guessTimes[2] = '12:30'
-		timeStringPad = guessTimes.reduce((prev, curr) =>
-			prev === null || prev.length < curr.length ? curr : prev
-		).length
-		console.log(timeStringPad)
-	}
+	if (guessTimes) timeStringPad = longestStringLength(guessTimes)
 	return (
 		'  ' +
 		guesses
@@ -150,13 +144,26 @@ export function drawResults(
 		boardContent,
 		guesses,
 		caption,
-	}: { highContrast: boolean; boardContent: Board; guesses: string[]; caption: string }
+		guessTimes,
+		showURL,
+		hash,
+	}: {
+		highContrast: boolean
+		boardContent: Board
+		guesses: string[]
+		caption: string
+		guessTimes?: string[]
+		showURL: boolean
+		hash?: string
+	}
 ): void {
 	if (!canvas) return
-	canvas.height = guesses.length * 100 + 60
+	canvas.width = 504 + (guessTimes ? longestStringLength(guessTimes) * 28 + 6 : 0)
+	canvas.style.width = Math.round(canvas.width / 2) + 'px'
+	canvas.height = guesses.length * 100 + 60 + (showURL ? 44 : 0)
 	const ctx = canvas.getContext('2d')!
 	ctx.fillStyle = highContrast ? '#161a25' : '#312236'
-	ctx.fillRect(0, 0, 504, 660)
+	ctx.fillRect(0, 0, canvas.width, canvas.height)
 	const roundedRectangle = (
 		x: number,
 		y: number,
@@ -175,6 +182,9 @@ export function drawResults(
 		ctx.closePath()
 		ctx.fill()
 	}
+	ctx.font = '50px Arial'
+	ctx.textAlign = 'right'
+	ctx.textBaseline = 'middle'
 	boardContent.forEach((row, r) => {
 		if (r >= guesses.length) return
 		row.forEach((tile, t) => {
@@ -194,9 +204,23 @@ export function drawResults(
 			const l = 88
 			roundedRectangle(x, y, l, l, topRadius, bottomRadius)
 		})
+		if (guessTimes) {
+			ctx.fillStyle = '#a7a1a9'
+			ctx.fillText(guessTimes[r], canvas.width - 6, r * 100 + 55)
+		}
 	})
+	ctx.fillStyle = '#cccccc'
 	ctx.font = '40px Arial'
 	ctx.textAlign = 'center'
-	ctx.fillStyle = '#cccccc'
-	ctx.fillText(caption, 252, guesses.length * 100 + 44)
+	ctx.textBaseline = 'alphabetic'
+	ctx.fillText(caption, canvas.width / 2, guesses.length * 100 + 44)
+	if (showURL) {
+		let url = 'wordlepeaks.com'
+		if (hash) url += '/#' + hash
+		ctx.fillStyle = '#a7a1a9'
+		ctx.fillText(url, canvas.width / 2, guesses.length * 100 + 92)
+	}
 }
+
+const longestStringLength = (strArr: string[]) =>
+	strArr.reduce((prev, curr) => (prev === null || prev.length < curr.length ? curr : prev)).length

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -159,7 +159,7 @@ export function drawResults(
 ): void {
 	if (!canvas) return
 	canvas.width = 504 + (guessTimes ? longestStringLength(guessTimes) * 28 + 6 : 0)
-	canvas.style.width = Math.round(canvas.width / 2) + 'px'
+	canvas.style.maxWidth = `min(100%, ${Math.round(canvas.width / 2)}px)`
 	canvas.height = guesses.length * 100 + 60 + (showURL ? 44 : 0)
 	const ctx = canvas.getContext('2d')!
 	ctx.fillStyle = highContrast ? '#161a25' : '#312236'

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,4 +1,4 @@
-import { ROWS } from '$lib/data-model'
+import { encodeWord, ROWS } from '$lib/data-model'
 import type { GameMode } from '$lib/data-model'
 import * as store from '$src/store'
 import { get } from 'svelte/store'
@@ -26,6 +26,7 @@ export type GameDetail = {
 	answer: string
 	guesses: string[]
 	guessTimes: number[]
+	hash: string | null
 }
 
 export function saveGameDetail() {
@@ -37,6 +38,7 @@ export function saveGameDetail() {
 		answer: get(store.answer),
 		guesses: get(store.guesses),
 		guessTimes: get(store.guessTimes),
+		hash: mode === 'daily' ? null : encodeWord(get(store.answer)),
 	})
 }
 

--- a/src/lib/translations/en/main.json
+++ b/src/lib/translations/en/main.json
@@ -60,7 +60,8 @@
 		"swap_enter_backspace": "Swap Enter/Backspace keys",
 		"alphabetic": "Alphabetic",
 		"use_dyslexic_font": "OpenDyslexic font",
-		"include_link": "Include link in share text"
+		"include_link": "Include link",
+		"include_times": "Include times"
 	},
 	"footer": {
 		"credits": "an <a href=\"https://github.com/vegeta897/wordle-peaks\">open source</a> project inspired by <a href=\"https://www.nytimes.com/games/wordle/index.html\">Wordle</a>",

--- a/src/lib/translations/es/main.json
+++ b/src/lib/translations/es/main.json
@@ -60,7 +60,8 @@
 		"swap_enter_backspace": "Intercambiar teclas Aceptar/Retroceso",
 		"alphabetic": "Alfabético",
 		"use_dyslexic_font": "Fuente OpenDyslexic",
-		"include_link": "Incluir enlace en el texto compartido"
+		"include_link": "Incluir enlace",
+		"include_times": "Incluir tiempos"
 	},
 	"footer": {
 		"credits": "un proyecto de <a href=\"https://github.com/vegeta897/wordle-peaks\">código abierto</a> inspirado en <a href=\"https://www.nytimes.com/games/wordle/index.html\">Wordle</a>",

--- a/src/lib/translations/fr/main.json
+++ b/src/lib/translations/fr/main.json
@@ -60,7 +60,8 @@
 		"swap_enter_backspace": "Échanger les touches Entrer/Retour",
 		"alphabetic": "Alphabétique",
 		"use_dyslexic_font": "Police OpenDyslexic",
-		"include_link": "Inclure le lien dans le texte de partage"
+		"include_link": "Inclure le lien",
+		"include_times": "Inclure temps"
 	},
 	"footer": {
 		"credits": "un projet <a href=\"https://github.com/vegeta897/wordle-peaks\">open source</a> inspiré par <a href=\"https://www.nytimes.com/games/wordle/index.html\">Wordle</a>",

--- a/src/lib/translations/nl/main.json
+++ b/src/lib/translations/nl/main.json
@@ -60,7 +60,8 @@
 		"swap_enter_backspace": "Wissel Enter/Backspace toetsen",
 		"alphabetic": "Alfabetisch",
 		"use_dyslexic_font": "OpenDyslexic lettertype",
-		"include_link": "Link opnemen in deeltekst"
+		"include_link": "Link opnemen",
+		"include_times": "Inclusief duur"
 	},
 	"footer": {
 		"credits": "een <a href=\"https://github.com/vegeta897/wordle-peaks\">open source</a> project geïnspireerd door <a href=\"https://www.nytimes.com/games/wordle/index.html\">Wordle</a>",

--- a/src/lib/translations/pt/main.json
+++ b/src/lib/translations/pt/main.json
@@ -60,7 +60,8 @@
 		"swap_enter_backspace": "Trocar a posição das teclas Enter/Apagar",
 		"alphabetic": "Alfabético",
 		"use_dyslexic_font": "Fonte OpenDyslexic",
-		"include_link": "Incluir link no texto de compartilhamento"
+		"include_link": "Incluir link",
+		"include_times": "Incluir tempos"
 	},
 	"footer": {
 		"credits": "um projeto <a href=\"https://github.com/vegeta897/wordle-peaks\">open source</a> inspirado por <a href=\"https://www.nytimes.com/games/wordle/index.html\">Wordle</a>",

--- a/src/lib/translations/tr/main.json
+++ b/src/lib/translations/tr/main.json
@@ -60,7 +60,8 @@
 		"swap_enter_backspace": "Enter ve Backspace tuşlarının yerini değiştir",
 		"alphabetic": "Alfabetik",
 		"use_dyslexic_font": "OpenDyslexic yazı tipi",
-		"include_link": "Paylaş metnine adresi ekle"
+		"include_link": "Adresi ekle",
+		"include_times": "Süre ekle"
 	},
 	"footer": {
 		"credits": "<a href=\"https://www.nytimes.com/games/wordle/index.html\">Wordle'dan</a> esinlenilmiş <a href=\"https://github.com/vegeta897/wordle-peaks\">açık kaynak</a> kodlu bir proje",

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -94,7 +94,6 @@
 		<Tutorial />
 	{:else if $openScreen === 'results'}
 		<Results
-			{hash}
 			playDaily={() => {
 				openScreen.set(null)
 				gameMode.set('daily')

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -20,6 +20,7 @@ export const keyboardLayout: Writable<KeyboardLayout> = storageWritable(
 )
 export const dyslexicFont: Writable<boolean> = storageWritable('wp-dyslexicFont', false)
 export const shareURL: Writable<boolean> = storageWritable('wp-shareURL', true)
+export const shareTimes: Writable<boolean> = storageWritable('wp-shareTimes', false)
 
 export const lastPlayedDaily: Writable<number> = storageWritable('wp-lastPlayedDaily', -1)
 

--- a/src/store/validation.ts
+++ b/src/store/validation.ts
@@ -20,6 +20,7 @@ export function validateLocalStorage() {
 	if (![true, false].includes(get(app.swapEnterBackspace))) app.swapEnterBackspace.set(false)
 	if (![true, false].includes(get(app.dyslexicFont))) app.dyslexicFont.set(false)
 	if (![true, false].includes(get(app.shareURL))) app.shareURL.set(true)
+	if (![true, false].includes(get(app.shareTimes))) app.shareTimes.set(false)
 	if (!keyboardLayoutNames.includes(get(app.keyboardLayout))) app.keyboardLayout.set('qwerty')
 
 	// Stats


### PR DESCRIPTION
Prompted by [a tweet](https://twitter.com/TMSMashups/status/1531978857456103425), I added the option to include guess times in the share text and image.

To make this option more visible and convenient, I moved it (along with the share URL option) right into the share menu. I also decided to change the layout of the results screen a bit, moving the share button/menu inside the Summary tab, and moving the play buttons below the tab section. This aligns better with the expected user flow.

I also improved the image sharing by including the URL if that option is enabled. The puzzle hash will be included if it was a random word.