### PR TITLE
Fix image sharing on mobile

### DIFF
--- a/src/components/EndButtons.svelte
+++ b/src/components/EndButtons.svelte
@@ -83,9 +83,6 @@
 		)
 	}
 
-	// TODO: Share menu doesn't pop up on android firefox
-	// TODO: Copy image doesn't work on phones
-
 	async function onBoardImageShare() {
 		showScoreShareMenu = false
 		const { hash, dayNumber } = get(store.lastGameDetail)!
@@ -99,10 +96,12 @@
 			showURL: get(store.shareURL),
 			hash: hash || undefined,
 		})
-		canvas.toBlob((blob) => (canvasBlob = blob!))
+		canvas.toBlob((blob) => {
+			canvasBlob = blob!
+			shareImage(canvasBlob, `${hash || dayNumber}`)
+		})
 		showImageShare = true
 		trackEvent('resultShare')
-		await shareImage(canvas, `${hash || dayNumber}`)
 		canvas.scrollIntoView({ block: 'center' })
 	}
 
@@ -113,11 +112,13 @@
 			color,
 			highContrast: get(store.highContrast),
 		})
-		canvas.toBlob((blob) => (canvasBlob = blob!))
+		canvas.toBlob((blob) => {
+			canvasBlob = blob!
+			shareImage(canvasBlob, `${hash || dayNumber}-landscape${color ? '-color' : ''}`)
+		})
 		showImageShare = true
 		trackEvent('landscapeShare')
 		const { hash, dayNumber } = get(store.lastGameDetail)!
-		await shareImage(canvas, `${hash || dayNumber}-landscape${color ? '-color' : ''}`)
 		canvas.scrollIntoView({ block: 'center' })
 	}
 

--- a/src/components/EndButtons.svelte
+++ b/src/components/EndButtons.svelte
@@ -31,6 +31,7 @@
 	let showScoreShareMenu: boolean
 	let showImageShare: boolean
 	let canvas: HTMLCanvasElement
+	let canvasBlob: Blob
 	let shareTitleText: string
 	let landscapeRedrawCooldown = false
 
@@ -82,6 +83,9 @@
 		)
 	}
 
+	// TODO: Share menu doesn't pop up on android firefox
+	// TODO: Copy image doesn't work on phones
+
 	async function onBoardImageShare() {
 		showScoreShareMenu = false
 		const { hash, dayNumber } = get(store.lastGameDetail)!
@@ -95,20 +99,11 @@
 			showURL: get(store.shareURL),
 			hash: hash || undefined,
 		})
+		canvas.toBlob((blob) => (canvasBlob = blob!))
 		showImageShare = true
 		trackEvent('resultShare')
 		await shareImage(canvas, `${hash || dayNumber}`)
 		canvas.scrollIntoView({ block: 'center' })
-	}
-
-	function onCopyImage() {
-		try {
-			copyImage(canvas)
-			showImageShare = false
-			successToast(get(t)('main.messages.image_copied'))
-		} catch (e) {
-			errorToast()
-		}
 	}
 
 	async function onLandscapeShare() {
@@ -118,11 +113,22 @@
 			color,
 			highContrast: get(store.highContrast),
 		})
+		canvas.toBlob((blob) => (canvasBlob = blob!))
 		showImageShare = true
 		trackEvent('landscapeShare')
 		const { hash, dayNumber } = get(store.lastGameDetail)!
 		await shareImage(canvas, `${hash || dayNumber}-landscape${color ? '-color' : ''}`)
 		canvas.scrollIntoView({ block: 'center' })
+	}
+
+	function onCopyImage() {
+		try {
+			copyImage(canvasBlob)
+			showImageShare = false
+			successToast(get(t)('main.messages.image_copied'))
+		} catch (e) {
+			errorToast()
+		}
 	}
 
 	const nextDailyTime = getDayEnd(get(store.lastPlayedDaily)).getTime()

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -55,11 +55,8 @@ export function copyText(text: string): Promise<void> {
 	return navigator.clipboard.writeText(text)
 }
 
-export function copyImage(canvas: HTMLCanvasElement): void {
-	canvas.toBlob(async (blob) => {
-		let data = [new ClipboardItem({ [blob!.type]: blob! })]
-		await navigator.clipboard.write(data)
-	})
+export async function copyImage(blob: Blob): Promise<void> {
+	await navigator.clipboard.write([new ClipboardItem({ [blob!.type]: blob! })])
 }
 
 // https://benkaiser.dev/sharing-images-using-the-web-share-api/

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -60,12 +60,10 @@ export async function copyImage(blob: Blob): Promise<void> {
 }
 
 // https://benkaiser.dev/sharing-images-using-the-web-share-api/
-export async function shareImage(canvas: HTMLCanvasElement, name: string): Promise<void> {
-	const imageUrl = canvas.toDataURL()
-	const imageBlob = await (await fetch(imageUrl)).blob()
+export async function shareImage(blob: Blob, name: string): Promise<void> {
 	const filesArray = [
-		new File([imageBlob], `word-peaks-${name}.png`, {
-			type: imageBlob.type,
+		new File([blob], `word-peaks-${name}.png`, {
+			type: blob.type,
 			lastModified: new Date().getTime(),
 		}),
 	]


### PR DESCRIPTION
Webkit on iOS is strict about copying to the clipboard in a callback, so I changed the code to create the canvas blob as soon as the canvas is drawn.

As for Firefox on Android, there isn't much hope. It doesn't seem to support sharing OR copying image data.