### PR TITLE
Add reverse alphabetical keyboard layout

### DIFF
--- a/src/components/Options.svelte
+++ b/src/components/Options.svelte
@@ -25,6 +25,9 @@
 		_keyboardLayoutOptions.find((o) => o.value === 'alphabetic')!.label = get(t)(
 			'main.options.alphabetic'
 		)
+		_keyboardLayoutOptions.find((o) => o.value === 'alphabetic_reversed')!.label = get(t)(
+			'main.options.alphabetic_reversed'
+		)
 		_keyboardLayoutOptions = _keyboardLayoutOptions
 	}
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,6 +10,7 @@ export const keyboardLayoutNames = [
 	'qwertz',
 	'dvorak',
 	'colemak',
+	'alphabetic_reversed',
 ] as const
 export type KeyboardLayout = typeof keyboardLayoutNames[number]
 export const keyboardLayoutOptions: {
@@ -79,8 +80,8 @@ export const keyboardLayoutOptions: {
 		wideKeysRow: 2,
 	},
 	{
-		value: 'reverse_alphabetic',
-		label: 'Reverse Alphabetic [Z-A]',
+		value: 'alphabetic_reversed',
+		label: 'Alphabetic (reversed)',
 		layout: [
 			['z', 'y', 'x', 'w', 'v', 'u', 't', 's', 'r', 'q'],
 			['p', 'o', 'n', 'm', 'l', 'k', 'j', 'i', 'h', 'g'],

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -78,6 +78,16 @@ export const keyboardLayoutOptions: {
 		],
 		wideKeysRow: 2,
 	},
+	{
+		value: 'reverse_alphabetic',
+		label: 'Reverse Alphabetic [Z-A]',
+		layout: [
+			['z', 'y', 'x', 'w', 'v', 'u', 't', 's', 'r', 'q'],
+			['p', 'o', 'n', 'm', 'l', 'k', 'j', 'i', 'h', 'g'],
+			['f', 'e', 'd', 'c', 'b', 'a'],
+		],
+		wideKeysRow: 2,
+	},
 ]
 
 export const OptionsIconPathData =

--- a/src/lib/translations/en/main.json
+++ b/src/lib/translations/en/main.json
@@ -81,7 +81,7 @@
 		"show_all_hints": "Show all hints in row",
 		"swap_enter_backspace": "Swap Enter/Backspace keys",
 		"alphabetic": "Alphabetic",
-        "reverse_alphabetic": "Alphabetic (reversed)",
+		"alphabetic_reversed": "Alphabetic (reversed)",
 		"use_dyslexic_font": "OpenDyslexic font",
 		"hide_landscape": "Hide landscape",
 		"allow_dancing_letters": "Allow dancing letters",

--- a/src/lib/translations/en/main.json
+++ b/src/lib/translations/en/main.json
@@ -81,6 +81,7 @@
 		"show_all_hints": "Show all hints in row",
 		"swap_enter_backspace": "Swap Enter/Backspace keys",
 		"alphabetic": "Alphabetic",
+        "reverse_alphabetic": "Alphabetic (reversed)",
 		"use_dyslexic_font": "OpenDyslexic font",
 		"hide_landscape": "Hide landscape",
 		"allow_dancing_letters": "Allow dancing letters",


### PR DESCRIPTION
This adds a new reversed alphabetical keyboard layout. This is useful for visualizing what letters are left, as it makes the "arrow" clues now point to the section of the keyboard that is remaining.